### PR TITLE
Allow custom calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ calendar.business_day?(Date.parse("Sunday, 8 June 2014"))
 # => false
 ```
 
+### Custom calendars
+
+To use a calendar you've written yourself, you need to add the directory it's
+stored in as an additional calendar load path:
+
+```ruby
+Business::Calendar.additional_load_paths = ['path/to/your/calendar/directory']
+```
+
+You can then load the calendar as normal.
+
 ### Business day arithmetic
 
 The `add_business_days` and `subtract_business_days` are used to perform
@@ -85,7 +96,6 @@ date = Date.parse("Saturday, 14 June 2014")
 calendar.business_days_between(date, date + 7)
 # => 5
 ```
-
 
 ## But other libraries already do this
 

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -2,10 +2,23 @@ require 'yaml'
 
 module Business
   class Calendar
+    class << self
+      attr_accessor :additional_load_paths
+    end
+
+    def self.calendar_directories
+      directories = @additional_load_paths || []
+      directories + [File.join(File.dirname(__FILE__), 'data')]
+    end
+    private_class_method :calendar_directories
+
     def self.load(calendar)
-      path = File.join(File.dirname(__FILE__), 'data', "#{calendar}.yml")
-      raise "No such calendar '#{calendar}'" unless File.exists?(path)
-      yaml = YAML.load_file(path)
+      directory = calendar_directories.find do |dir|
+        File.exists?(File.join(dir, "#{calendar}.yml"))
+      end
+      raise "No such calendar '#{calendar}'" unless directory
+
+      yaml = YAML.load_file(File.join(directory, "#{calendar}.yml"))
       self.new(holidays: yaml['holidays'], working_days: yaml['working_days'])
     end
 

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -21,6 +21,34 @@ describe Business::Calendar do
       it { is_expected.to be_a Business::Calendar }
     end
 
+    context "when given a calendar from a custom directory" do
+      before do
+        Business::Calendar.additional_load_paths = [
+          File.join(File.dirname(__FILE__), 'fixtures', 'calendars')
+        ]
+      end
+      after { Business::Calendar.additional_load_paths = nil }
+      subject { Business::Calendar.load("ecb") }
+
+      it "loads the yaml file" do
+        expect(YAML).to receive(:load_file) { |path|
+          expect(path).to match(/ecb\.yml$/)
+        }.and_return({})
+        subject
+      end
+
+      it { is_expected.to be_a Business::Calendar }
+
+      context "that also exists as a default calendar" do
+        subject { Business::Calendar.load("bacs") }
+
+        it "uses the custom calendar" do
+          expect(subject.business_day?(Date.parse("25th December 2014"))).
+            to eq(true)
+        end
+      end
+    end
+
     context "when given an invalid calendar" do
       subject { Business::Calendar.load("invalid-calendar") }
       specify { expect{ subject }.to raise_error }

--- a/spec/fixtures/calendars/bacs.yml
+++ b/spec/fixtures/calendars/bacs.yml
@@ -1,0 +1,9 @@
+working_days:
+  - monday
+  - tuesday
+  - wednesday
+  - thursday
+  - friday
+
+holidays:
+  - January 1st, 2015

--- a/spec/fixtures/calendars/ecb.yml
+++ b/spec/fixtures/calendars/ecb.yml
@@ -1,0 +1,49 @@
+working_days:
+  - monday
+  - tuesday
+  - wednesday
+  - thursday
+  - friday
+
+holidays:
+  - January 1st, 2013
+  - March 29th, 2013
+  - April 1st, 2013
+  - May 1st, 2013
+  - May 9th, 2013
+  - May 20th, 2013
+  - May 30th, 2013
+  - October 3rd, 2013
+  - November 1st, 2013
+  - December 24th, 2013
+  - December 25th, 2013
+  - December 26th, 2013
+  - December 31st, 2013
+  - January 1st, 2014
+  - April 18th, 2014
+  - April 21st, 2014
+  - May 1st, 2014
+  - May 9th, 2014
+  - May 29th, 2014
+  - June 9th, 2014
+  - June 19th, 2014
+  - October 3rd, 2014
+  - November 1st, 2014
+  - December 24th, 2014
+  - December 25th, 2014
+  - December 26th, 2014
+  - December 31st, 2014
+  - January 1st, 2015
+  - April 3rd, 2015
+  - April 6th, 2015
+  - May 1st, 2015
+  - May 9th, 2015
+  - May 14th, 2015
+  - May 25th, 2015
+  - June 4th, 2015
+  - October 3rd, 2015
+  - November 1st, 2015
+  - December 24th, 2015
+  - December 25th, 2015
+  - December 26th, 2015
+  - December 31st, 2015


### PR DESCRIPTION
Allow additional calendar directories to be specified using `Business::Calendar.additional_directories`
