### PR TITLE
Add public holidays for BECS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can then load the calendar as normal.
 ### Business day arithmetic
 
 The `add_business_days` and `subtract_business_days` are used to perform
-business day arithemtic on dates.
+business day arithmetic on dates.
 
 ```ruby
 date = Date.parse("Thursday, 12 June 2014")
@@ -96,6 +96,18 @@ date = Date.parse("Saturday, 14 June 2014")
 calendar.business_days_between(date, date + 7)
 # => 5
 ```
+
+### Included Calendars
+
+We include some calendar data with this Gem but give no guarantees of its
+accuracy.
+The calendars that we include are:
+
+* Bacs
+* Bankgirot
+* BECS
+* Betalingsservice
+* Target (SEPA)
 
 ## But other libraries already do this
 

--- a/lib/business/data/becs.yml
+++ b/lib/business/data/becs.yml
@@ -1,0 +1,22 @@
+working_days:
+  - monday
+  - tuesday
+  - wednesday
+  - thursday
+  - friday
+
+holidays:
+  - January 1st, 2017
+  - January 26th, 2017
+  - April 14th, 2017
+  - April 17th, 2017
+  - April 25th, 2017
+  - December 25th, 2017
+  - December 26th, 2017
+  - January 1st, 2018
+  - January 26th, 2018
+  - March 30th, 2018
+  - April 2nd, 2018
+  - April 25th, 2018
+  - December 25th, 2018
+  - December 26th, 2018


### PR DESCRIPTION
These are holidays that apply to all Australian regions.

Variable dates (i.e Holidays that relate to Easter) pulled from [australia.gov.au](http://www.australia.gov.au/about-australia/special-dates-and-events/public-holidays)