### PR TITLE
Remove 24th December 2018/2019 from Betalingsservice calendar

### DIFF
--- a/lib/business/data/betalingsservice.yml
+++ b/lib/business/data/betalingsservice.yml
@@ -26,7 +26,6 @@ holidays:
   - May 11th, 2018
   - May 21st, 2018
   - June 5th, 2018
-  - December 24th, 2018
   - December 25th, 2018
   - December 26th, 2018
   - December 31st, 2018
@@ -39,7 +38,6 @@ holidays:
   - May 31st, 2019
   - June 5th, 2019
   - June 10th, 2019
-  - December 24th, 2019
   - December 25th, 2019
   - December 26th, 2019
   - December 31st, 2019


### PR DESCRIPTION
Prior to the Betalingsservice calendar being released, we were relying on https://danskebank.dk/PDF/PRISER-VILKAAR-FAKTAARK/Homepage-UK/Privat/Payments/General-Conditions-for-Betalingsservice-Debtors.pdf and https://publicholidays.dk/2018-dates/ to infer the Betalingsservice dates. Looks like we got this right, except in one case.

The official calendar is now here: https://www.betalingsservice.dk/Dokumenter_/Documents/Betalingsservice/BS_kalender_2018.pdf