### PR TITLE
Add holidays to becs and betalingsservice

### DIFF
--- a/lib/business/data/becs.yml
+++ b/lib/business/data/becs.yml
@@ -20,3 +20,17 @@ holidays:
   - April 25th, 2018
   - December 25th, 2018
   - December 26th, 2018
+  - January 1st, 2019
+  - January 28th, 2019
+  - April 19th, 2019
+  - April 22nd, 2019
+  - April 25th, 2019
+  - December 25th, 2019
+  - December 26th, 2019
+  - January 1st, 2020
+  - January 27th, 2020
+  - April 10th, 2020
+  - April 13nd, 2020
+  - April 25th, 2020
+  - December 25th, 2020
+  - December 28th, 2020

--- a/lib/business/data/betalingsservice.yml
+++ b/lib/business/data/betalingsservice.yml
@@ -41,3 +41,14 @@ holidays:
   - December 25th, 2019
   - December 26th, 2019
   - December 31st, 2019
+  - January 1st, 2020
+  - April 9th, 2020
+  - April 10th, 2020
+  - April 12th, 2020
+  - April 13th, 2020
+  - May 8th, 2020
+  - May 31st, 2020
+  - June 1st, 2020
+  - June 5th, 2020
+  - December 25th, 2020
+  - December 26th, 2020

--- a/lib/business/version.rb
+++ b/lib/business/version.rb
@@ -1,3 +1,3 @@
 module Business
-  VERSION = "1.11.1"
+  VERSION = "1.12.0"
 end


### PR DESCRIPTION
Youtrack: https://gocardless.myjetbrains.com/youtrack/issue/CT-903

Denmark holidays: https://publicholidays.dk/2020-dates/
Australia holidays: https://publicholidays.com.au/2020-dates/ 

Note that at the time of this PR, the http servers for the above URLs responded with 404 when passed a year > 2020.