### PR TITLE
Add Calendar for BECS New Zealand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.0 - July 18, 2018
+
+- Add holiday calendar for BECS New Zealand
+
 ## 1.13.1 - June 22, 2018
 
 - Fix June's 2018 bank holidays for Bankgirot

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The calendars that we include are:
 
 * Bacs
 * Bankgirot
-* BECS
+* BECS (Australia)
+* BECSNZ (New Zealand)
 * Betalingsservice
 * Target (SEPA)
 

--- a/lib/business/data/becsnz.yml
+++ b/lib/business/data/becsnz.yml
@@ -1,0 +1,50 @@
+working_days:
+  - monday
+  - tuesday
+  - wednesday
+  - thursday
+  - friday
+
+holidays:
+  - January 2nd, 2017
+  - January 3rd, 2017
+  - February 6th, 2017
+  - April 14th, 2017
+  - April 17th, 2017
+  - April 25th, 2017
+  - June 5th, 2017
+  - October 23rd, 2017
+  - December 25th, 2017
+  - December 26th, 2017
+  - January 1st, 2018
+  - January 2nd, 2018
+  - February 6th, 2018
+  - March 30th, 2018
+  - April 2nd, 2018
+  - April 25th, 2018
+  - June 4th, 2018
+  - October 22nd, 2018
+  - December 25th, 2018
+  - December 26th, 2018
+  - January 1st, 2019
+  - January 2nd, 2019
+  - February 6th, 2019
+  - April 19th, 2019
+  - April 22nd, 2019
+  - April 25th, 2019
+  - June 3rd, 2019
+  - October 28th, 2019
+  - December 25th, 2019
+  - December 26th, 2019
+  - January 1st, 2020
+  - January 2nd, 2020
+  - February 6th, 2020
+  - April 10th, 2020
+  - April 13th, 2020
+  - April 27th, 2020
+  - June 1st, 2020
+  - October 26th, 2020
+  - December 25th, 2020
+  - December 28th, 2020
+
+

--- a/lib/business/version.rb
+++ b/lib/business/version.rb
@@ -1,3 +1,3 @@
 module Business
-  VERSION = "1.13.1"
+  VERSION = "1.14.0"
 end


### PR DESCRIPTION
Data for 2017 - 2020 obtained from
https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/