### PR TITLE
[CA] Add PAD holiday calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.0 - October 24, 2018
+
+- Add holiday calendar for PAD Canada
+
 ## 1.14.0 - July 18, 2018
 
 - Add holiday calendar for BECS New Zealand

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The calendars that we include are:
 * Bankgirot
 * BECS (Australia)
 * BECSNZ (New Zealand)
+* PAD (Canada)
 * Betalingsservice
 * Target (SEPA)
 

--- a/lib/business/data/padca.yml
+++ b/lib/business/data/padca.yml
@@ -1,0 +1,44 @@
+working_days:
+  - monday
+  - tuesday
+  - wednesday
+  - thursday
+  - friday
+
+holidays:
+  - January 1st, 2018
+  - January 2nd, 2018
+  - February 12th, 2018
+  - February 19th, 2018
+  - March 30th, 2018
+  - April 2nd, 2018
+  - May 21st, 2018
+  - June 21st, 2018
+  - June 25th, 2018
+  - July 2nd, 2018
+  - July 9th, 2018
+  - August 6th, 2018
+  - August 20th, 2018
+  - September 3rd, 2018
+  - October 8th, 2018
+  - November 12th, 2018
+  - December 25th, 2018
+  - December 26th, 2018
+  - January 1st, 2019
+  - January 2nd, 2019
+  - February 11th, 2019
+  - February 18th, 2019
+  - April 19th, 2019
+  - April 22nd, 2019
+  - May 20th, 2019
+  - June 21st, 2019
+  - June 24th, 2019
+  - July 1st, 2019
+  - July 9th, 2019
+  - August 5th, 2019
+  - August 19th, 2019
+  - September 2nd, 2019
+  - October 14th, 2019
+  - November 11th, 2019
+  - December 25th, 2019
+  - December 26th, 2019

--- a/lib/business/data/padca.yml
+++ b/lib/business/data/padca.yml
@@ -7,38 +7,21 @@ working_days:
 
 holidays:
   - January 1st, 2018
-  - January 2nd, 2018
-  - February 12th, 2018
-  - February 19th, 2018
   - March 30th, 2018
-  - April 2nd, 2018
   - May 21st, 2018
-  - June 21st, 2018
-  - June 25th, 2018
   - July 2nd, 2018
-  - July 9th, 2018
-  - August 6th, 2018
-  - August 20th, 2018
   - September 3rd, 2018
   - October 8th, 2018
   - November 12th, 2018
   - December 25th, 2018
   - December 26th, 2018
   - January 1st, 2019
-  - January 2nd, 2019
-  - February 11th, 2019
-  - February 18th, 2019
   - April 19th, 2019
-  - April 22nd, 2019
   - May 20th, 2019
-  - June 21st, 2019
-  - June 24th, 2019
   - July 1st, 2019
-  - July 9th, 2019
-  - August 5th, 2019
-  - August 19th, 2019
   - September 2nd, 2019
   - October 14th, 2019
   - November 11th, 2019
   - December 25th, 2019
   - December 26th, 2019
+  - January 1st, 2020

--- a/lib/business/version.rb
+++ b/lib/business/version.rb
@@ -1,3 +1,3 @@
 module Business
-  VERSION = "1.14.0"
+  VERSION = "1.15.0"
 end


### PR DESCRIPTION
Add holiday calendar for Canada PAD.

Source of data is https://www.rbcroyalbank.com/ach/cid-264772.html

# Things to note
~~It appears Canada has holidays that are only for a specific region however in this PR is a superset of all of them.
A potential later refinement would be to have specific holiday calendars for each region then leave it up to the consumer to narrow down exactly which holiday calendar they need.~~
Decision taken to use the national holidays and regional holidays supported in Ontario as that matches our use case. 