### PR TITLE
Update May Day 2020 for Bacs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.1 - November 19, 2019
+
+- Change May Bank Holiday 2020 for UK (Bacs) - this was moved to the 8th.
+- Add 2020 holidays for PAD.
+
 ## 1.17.0 - September 2, 2019
 
 - Add holiday calendar for France (Target(SEPA) + French bank holidays)

--- a/lib/business/data/bacs.yml
+++ b/lib/business/data/bacs.yml
@@ -65,7 +65,7 @@ holidays:
   - January 1st, 2020
   - April 10th, 2020
   - April 13th, 2020
-  - May 4th, 2020
+  - May 8th, 2020
   - May 25th, 2020
   - August 31st, 2020
   - December 25th, 2020

--- a/lib/business/version.rb
+++ b/lib/business/version.rb
@@ -1,3 +1,3 @@
 module Business
-  VERSION = "1.17.0"
+  VERSION = "1.17.1"
 end


### PR DESCRIPTION
This was changed to mark the 75th anniversary of VE Day.