### PR TITLE
Add Danish holidays for 2021

### DIFF
--- a/lib/business/data/betalingsservice.yml
+++ b/lib/business/data/betalingsservice.yml
@@ -54,3 +54,16 @@ holidays:
   - December 25th, 2020
   - December 26th, 2020
   - December 31st, 2020
+  - January 1st, 2021
+  - April 1st, 2021
+  - April 2nd, 2021
+  - April 5th, 2021
+  - April 30th, 2021
+  - May 13th, 2021
+  - May 14th, 2021
+  - May 24th, 2021
+  - June 5th, 2021
+  - December 24th, 2021
+  - December 25th, 2021
+  - December 26th, 2021
+  - December 31st, 2021


### PR DESCRIPTION
2021:
- https://www.officeholidays.com/countries/denmark/2021

We should double check when the 2021 calendar is out