### PR TITLE
Save calendar name reference in loaded calendar

### DIFF
--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -29,7 +29,7 @@ module Business
         name: calendar_name,
         holidays: data["holidays"],
         working_days: data["working_days"],
-        extra_working_dates: data["extra_working_days"],
+        extra_working_dates: data["extra_working_dates"],
       )
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -25,9 +25,8 @@ module Business
       end
 
       new(
-        holidays: data["holidays"],
-        working_days: data["working_days"],
-        extra_working_dates: data["extra_working_dates"],
+        calendar_name,
+        **data.slice("holidays", "working_days", "extra_working_days"),
       )
     end
 
@@ -54,9 +53,10 @@ module Business
 
     DAY_NAMES = %( mon tue wed thu fri sat sun )
 
-    attr_reader :holidays, :working_days, :extra_working_dates
+    attr_reader :name, :holidays, :working_days, :extra_working_dates
 
-    def initialize(config)
+    def initialize(name, config)
+      @name = name
       set_extra_working_dates(config[:extra_working_dates])
       set_working_days(config[:working_days])
       set_holidays(config[:holidays])

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -16,6 +16,7 @@ module Business
     end
     private_class_method :calendar_directories
 
+    # rubocop:disable Metrics/MethodLength
     def self.load(calendar_name)
       data = find_calendar_data(calendar_name)
       raise "No such calendar '#{calendar_name}'" unless data
@@ -31,6 +32,7 @@ module Business
         extra_working_dates: data["extra_working_days"],
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     def self.find_calendar_data(calendar_name)
       calendar_directories.detect do |path|
@@ -55,7 +57,7 @@ module Business
 
     DAY_NAMES = %( mon tue wed thu fri sat sun )
 
-    attr_reader :name,:holidays, :working_days, :extra_working_dates
+    attr_reader :name, :holidays, :working_days, :extra_working_dates
 
     def initialize(name:, extra_working_dates: nil, working_days: nil, holidays: nil)
       @name = name

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -25,8 +25,10 @@ module Business
       end
 
       new(
-        calendar_name,
-        **data.slice("holidays", "working_days", "extra_working_days"),
+        name: calendar_name,
+        holidays: data["holidays"],
+        working_days: data["working_days"],
+        extra_working_dates: data["extra_working_days"],
       )
     end
 
@@ -53,13 +55,13 @@ module Business
 
     DAY_NAMES = %( mon tue wed thu fri sat sun )
 
-    attr_reader :name, :holidays, :working_days, :extra_working_dates
+    attr_reader :name,:holidays, :working_days, :extra_working_dates
 
-    def initialize(name, config)
+    def initialize(name:, extra_working_dates: nil, working_days: nil, holidays: nil)
       @name = name
-      set_extra_working_dates(config[:extra_working_dates])
-      set_working_days(config[:working_days])
-      set_holidays(config[:holidays])
+      set_extra_working_dates(extra_working_dates)
+      set_working_days(working_days)
+      set_holidays(holidays)
 
       unless (@holidays & @extra_working_dates).none?
         raise ArgumentError, "Holidays cannot be extra working dates"

--- a/spec/business/calendar_spec.rb
+++ b/spec/business/calendar_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Business::Calendar do
   describe "#set_working_days" do
     subject(:set_working_days) { calendar.set_working_days(working_days) }
 
-    let(:calendar) { described_class.new({}) }
+    let(:calendar) { described_class.new("test", {}) }
     let(:working_days) { [] }
 
     context "when given valid working days" do
@@ -123,7 +123,7 @@ RSpec.describe Business::Calendar do
   describe "#set_holidays" do
     subject(:holidays) { calendar.holidays }
 
-    let(:calendar) { described_class.new({}) }
+    let(:calendar) { described_class.new("test", {}) }
     let(:holiday_dates) { [] }
 
     before { calendar.set_holidays(holiday_dates) }
@@ -148,7 +148,7 @@ RSpec.describe Business::Calendar do
   describe "#set_extra_working_dates" do
     subject(:extra_working_dates) { calendar.extra_working_dates }
 
-    let(:calendar) { described_class.new({}) }
+    let(:calendar) { described_class.new("test", {}) }
     let(:extra_dates) { [] }
 
     before { calendar.set_extra_working_dates(extra_dates) }
@@ -172,7 +172,8 @@ RSpec.describe Business::Calendar do
 
   context "when holiday is also a working date" do
     let(:instance) do
-      described_class.new(holidays: ["2018-01-06"],
+      described_class.new("test",
+                          holidays: ["2018-01-06"],
                           extra_working_dates: ["2018-01-06"])
     end
 
@@ -184,7 +185,8 @@ RSpec.describe Business::Calendar do
 
   context "when working date on working day" do
     let(:instance) do
-      described_class.new(working_days: ["mon"],
+      described_class.new("test",
+                          working_days: ["mon"],
                           extra_working_dates: ["Monday 26th Mar, 2018"])
     end
 
@@ -202,7 +204,8 @@ RSpec.describe Business::Calendar do
       subject { calendar.business_day?(day) }
 
       let(:calendar) do
-        described_class.new(holidays: ["9am, Tuesday 1st Jan, 2013"],
+        described_class.new("test",
+                            holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
 
@@ -235,7 +238,8 @@ RSpec.describe Business::Calendar do
       subject { calendar.working_day?(day) }
 
       let(:calendar) do
-        described_class.new(holidays: ["9am, Tuesday 1st Jan, 2013"],
+        described_class.new("test",
+                            holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
 
@@ -268,7 +272,8 @@ RSpec.describe Business::Calendar do
       subject { calendar.holiday?(day) }
 
       let(:calendar) do
-        described_class.new(holidays: ["9am, Tuesday 1st Jan, 2013"],
+        described_class.new("test",
+                            holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
 
@@ -301,7 +306,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.roll_forward(date) }
 
       let(:calendar) do
-        described_class.new(holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -329,7 +334,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.roll_backward(date) }
 
       let(:calendar) do
-        described_class.new(holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -357,7 +362,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.next_business_day(date) }
 
       let(:calendar) do
-        described_class.new(holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -385,7 +390,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.previous_business_day(date) }
 
       let(:calendar) do
-        described_class.new(holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -414,7 +419,8 @@ RSpec.describe Business::Calendar do
 
       let(:extra_working_dates) { [] }
       let(:calendar) do
-        described_class.new(holidays: ["Tuesday 1st Jan, 2013"],
+        described_class.new("test",
+                            holidays: ["Tuesday 1st Jan, 2013"],
                             extra_working_dates: extra_working_dates)
       end
       let(:delta) { 2 }
@@ -458,7 +464,8 @@ RSpec.describe Business::Calendar do
 
       let(:extra_working_dates) { [] }
       let(:calendar) do
-        described_class.new(holidays: ["Thursday 3rd Jan, 2013"],
+        described_class.new("test",
+                            holidays: ["Thursday 3rd Jan, 2013"],
                             extra_working_dates: extra_working_dates)
       end
       let(:delta) { 2 }
@@ -511,7 +518,9 @@ RSpec.describe Business::Calendar do
         ["Sun 1/6/2014", "Sat 28/6/2014", "Sat 5/7/2014"]
       end
       let(:calendar) do
-        described_class.new(holidays: holidays, extra_working_dates: extra_working_dates)
+        described_class.new("test",
+                            holidays: holidays,
+                            extra_working_dates: extra_working_dates)
       end
 
       context "starting on a business day" do

--- a/spec/business/calendar_spec.rb
+++ b/spec/business/calendar_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Business::Calendar do
   describe "#set_working_days" do
     subject(:set_working_days) { calendar.set_working_days(working_days) }
 
-    let(:calendar) { described_class.new("test", {}) }
+    let(:calendar) { described_class.new(name: "test") }
     let(:working_days) { [] }
 
     context "when given valid working days" do
@@ -123,7 +123,7 @@ RSpec.describe Business::Calendar do
   describe "#set_holidays" do
     subject(:holidays) { calendar.holidays }
 
-    let(:calendar) { described_class.new("test", {}) }
+    let(:calendar) { described_class.new(name: "test") }
     let(:holiday_dates) { [] }
 
     before { calendar.set_holidays(holiday_dates) }
@@ -148,7 +148,7 @@ RSpec.describe Business::Calendar do
   describe "#set_extra_working_dates" do
     subject(:extra_working_dates) { calendar.extra_working_dates }
 
-    let(:calendar) { described_class.new("test", {}) }
+    let(:calendar) { described_class.new(name: "test") }
     let(:extra_dates) { [] }
 
     before { calendar.set_extra_working_dates(extra_dates) }
@@ -172,7 +172,7 @@ RSpec.describe Business::Calendar do
 
   context "when holiday is also a working date" do
     let(:instance) do
-      described_class.new("test",
+      described_class.new(name: "test",
                           holidays: ["2018-01-06"],
                           extra_working_dates: ["2018-01-06"])
     end
@@ -185,7 +185,7 @@ RSpec.describe Business::Calendar do
 
   context "when working date on working day" do
     let(:instance) do
-      described_class.new("test",
+      described_class.new(name: "test",
                           working_days: ["mon"],
                           extra_working_dates: ["Monday 26th Mar, 2018"])
     end
@@ -204,7 +204,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.business_day?(day) }
 
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
@@ -238,7 +238,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.working_day?(day) }
 
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
@@ -272,7 +272,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.holiday?(day) }
 
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: ["9am, Tuesday 1st Jan, 2013"],
                             extra_working_dates: ["9am, Sunday 6th Jan, 2013"])
       end
@@ -306,7 +306,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.roll_forward(date) }
 
       let(:calendar) do
-        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new(name: "test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -334,7 +334,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.roll_backward(date) }
 
       let(:calendar) do
-        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new(name: "test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -362,7 +362,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.next_business_day(date) }
 
       let(:calendar) do
-        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new(name: "test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -390,7 +390,7 @@ RSpec.describe Business::Calendar do
       subject { calendar.previous_business_day(date) }
 
       let(:calendar) do
-        described_class.new("test", holidays: ["Tuesday 1st Jan, 2013"])
+        described_class.new(name: "test", holidays: ["Tuesday 1st Jan, 2013"])
       end
 
       context "given a business day" do
@@ -419,7 +419,7 @@ RSpec.describe Business::Calendar do
 
       let(:extra_working_dates) { [] }
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: ["Tuesday 1st Jan, 2013"],
                             extra_working_dates: extra_working_dates)
       end
@@ -464,7 +464,7 @@ RSpec.describe Business::Calendar do
 
       let(:extra_working_dates) { [] }
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: ["Thursday 3rd Jan, 2013"],
                             extra_working_dates: extra_working_dates)
       end
@@ -518,7 +518,7 @@ RSpec.describe Business::Calendar do
         ["Sun 1/6/2014", "Sat 28/6/2014", "Sat 5/7/2014"]
       end
       let(:calendar) do
-        described_class.new("test",
+        described_class.new(name: "test",
                             holidays: holidays,
                             extra_working_dates: extra_working_dates)
       end


### PR DESCRIPTION
We use Business::Calendar at Modern Treasury.

There are a few use cases where we point a bank interface on a calendar based on several config values. It's helpful for us to sometimes print out the loaded configuration, including the calendar reference. I thought it would be helpful to have a `.name` reference on the calendar instance.