### PR TITLE
Make name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Get started with business by creating an instance of the calendar class, that ac
 ```ruby
 calendar = Business::Calendar.new(
   working_days: %w( mon tue wed thu fri ),
-  holidays: ["01/01/2014", "03/01/2014"]    # array items are either parseable date strings, or real Date objects
+  holidays: ["01/01/2014", "03/01/2014"],    # array items are either parseable date strings, or real Date objects
   extra_working_dates: [nil], # Makes the calendar to consider a weekend day as a working day.
 )
 ```

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -59,7 +59,7 @@ module Business
 
     attr_reader :name, :holidays, :working_days, :extra_working_dates
 
-    def initialize(name:, extra_working_dates: nil, working_days: nil, holidays: nil)
+    def initialize(name: nil, extra_working_dates: nil, working_days: nil, holidays: nil)
       @name = name
       set_extra_working_dates(extra_working_dates)
       set_working_days(working_days)

--- a/spec/business/calendar_spec.rb
+++ b/spec/business/calendar_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe Business::Calendar do
     end
   end
 
+  describe ".new" do
+    it "allows to set optional name" do
+      instance = described_class.new
+      expect(instance.name).to eq nil
+
+      instance = described_class.new(name: "foo")
+      expect(instance.name).to eq "foo"
+    end
+  end
+
   describe "#set_working_days" do
     subject(:set_working_days) { calendar.set_working_days(working_days) }
 


### PR DESCRIPTION
This fixes a regression introduced in 2.2.0. The `name` argument must not be mandatory, as it breaks the existing code which is not expected from the minor version.