### PR TITLE
Use YAML#safe_load_file with permitted_classes

### DIFF
--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -2,6 +2,7 @@
 
 require "yaml"
 require "date"
+require "pathname"
 
 module Business
   class Calendar
@@ -37,9 +38,10 @@ module Business
         if path.is_a?(Hash)
           break path[calendar_name] if path[calendar_name]
         else
-          next unless File.exist?(File.join(path, "#{calendar_name}.yml"))
+          calendar_path = Pathname.new(path).join("#{calendar_name}.yml")
+          next unless calendar_path.exist?
 
-          break YAML.load_file(File.join(path, "#{calendar_name}.yml"))
+          break YAML.safe_load(calendar_path.read, permitted_classes: [Date])
         end
       end
     end

--- a/spec/business/calendar_spec.rb
+++ b/spec/business/calendar_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Business::Calendar do
     subject(:load_calendar) { described_class.load(calendar) }
 
     let(:dummy_calendar) { { "working_days" => ["monday"] } }
+    let(:fixture_path) { File.join(File.dirname(__FILE__), "../fixtures", "calendars") }
 
     before do
-      fixture_path = File.join(File.dirname(__FILE__), "../fixtures", "calendars")
       described_class.load_paths = [fixture_path, { "foobar" => dummy_calendar }]
     end
 
@@ -25,7 +25,10 @@ RSpec.describe Business::Calendar do
       after { described_class.load_paths = nil }
 
       it "loads the yaml file" do
-        expect(YAML).to receive(:load_file).with(/ecb\.yml$/).and_return({})
+        path = Pathname.new(fixture_path).join("ecb.yml")
+        expect(YAML).to receive(:safe_load).
+          with(path.read, permitted_classes: [Date]).
+          and_return({})
 
         load_calendar
       end

--- a/spec/fixtures/calendars/ecb.yml
+++ b/spec/fixtures/calendars/ecb.yml
@@ -6,7 +6,7 @@ working_days:
   - friday
 
 holidays:
-  - January 1st, 2013
+  - 2013-01-01
   - March 29th, 2013
   - April 1st, 2013
   - May 1st, 2013


### PR DESCRIPTION
When using `Psych >= 4`, loading of dates in the format `YYYY-MM-DD` will fail.
I have included an example where this fails, and the fix. It requires the use of `permitted_classes` which is only available on the `safe_load_file` method.

It should be noted that this fix relies on `safe_load_file`, which seems to be available in `Psych >= 3.2.1`. Therefore if support is needed for older versions, then this will have to be changed to allow this.

![Psych 3.3.2, load_file passes](https://screenshot.click/28-53-bhw1m-fxx7u.png)
^ No change, older Psych; passes

![Psych 4, load_file failure](https://screenshot.click/28-55-71u5f-ydcnj.png)
^ No change, newer Psych; fails

![Psych 4, safe_load_file passes](https://screenshot.click/28-56-tzvkp-zfp4o.png)
^ With change, newer Psych; passes

![Psych 3.2.1, safe_load_file passes](https://screenshot.click/28-58-0qs0l-4ua15.png)
^ With change, older Psych; passes

![Psych 3.2.0, safe_load_file fails](https://screenshot.click/28-57-s79et-08zze.png)
^ With change, even older Psych; fails
