### PR TITLE
Drop unused "executables" gemspec directive

### DIFF
--- a/business.gemspec
+++ b/business.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["MIT"]
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.