### PR TITLE
Refactor `add_business_days` and `subtract_business_days`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, "3.0", 3.1, 3.2]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/lib/business/calendar.rb
+++ b/lib/business/calendar.rb
@@ -129,10 +129,7 @@ module Business
     def add_business_days(date, delta)
       date = roll_forward(date)
       delta.times do
-        loop do
-          date += day_interval_for(date)
-          break date if business_day?(date)
-        end
+        date = next_business_day(date)
       end
       date
     end
@@ -145,10 +142,7 @@ module Business
     def subtract_business_days(date, delta)
       date = roll_backward(date)
       delta.times do
-        loop do
-          date -= day_interval_for(date)
-          break date if business_day?(date)
-        end
+        date = previous_business_day(date)
       end
       date
     end


### PR DESCRIPTION
`add_business_days` and `subtract_business_days` are implemented by repeatedly applying `next_business_day` and `previous_business_day` respectively.

The code is identical. This refactor makes the intent  more explicit, improving readability.