### PR TITLE
Quote 3.0 to avoid truncation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2]
+        ruby-version: [2.6, 2.7, "3.0", 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
An unquoted "3.0" in the GitHub Actions configuration will be truncated to "3".  This loads the latest Ruby 3 (at this time Ruby 3.2.0) which is not what's intended for that entry.

This PR just adds quotes.