### PR TITLE
Add pull_request as a gh trigger action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: tests
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
 
 jobs:


### PR DESCRIPTION
When a public fork is created we only get sent the `pull_request` actions, not `push`.

This adds `pull_request` so we can approve GH Action runs

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories
