### PR TITLE
CI: Use actions/checkout@v4 to avoid deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR updates the GH Actions YAML config to avoid deprecation warnings in GH Actions itself.