### PR TITLE
CI: Extract RuboCop job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,23 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rm .ruby-version
+
+      - name: Set up the earliest-supported Ruby in our matrix
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+
+      - name: Run rubocop
+        run: bundle exec rubocop --parallel --extra-details --display-style-guide
+
   tests:
+    needs: [lint]
     strategy:
       matrix:
         ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
@@ -21,5 +37,3 @@ jobs:
           ruby-version: "${{ matrix.ruby-version }}"
       - name: Run tests
         run: bundle exec rspec
-      - name: Run rubocop
-        run: bundle exec rubocop --parallel --extra-details --display-style-guide


### PR DESCRIPTION
Only run for the lowest version of Ruby we support. Fixes #185 